### PR TITLE
feature: Adds analyzer support for logger BeginScope usage

### DIFF
--- a/src/LoggerUsage/Analyzers/BeginScopeAnalyzer.cs
+++ b/src/LoggerUsage/Analyzers/BeginScopeAnalyzer.cs
@@ -1,0 +1,73 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+using LoggerUsage.Models;
+using Microsoft.Extensions.Logging;
+
+namespace LoggerUsage.Analyzers
+{
+    internal class BeginScopeAnalyzer(ILoggerFactory loggerFactory) : ILoggerUsageAnalyzer
+    {
+        private readonly ILogger<BeginScopeAnalyzer> _logger = loggerFactory.CreateLogger<BeginScopeAnalyzer>();
+
+        public IEnumerable<LoggerUsageInfo> Analyze(LoggingTypes loggingTypes, SyntaxNode root, SemanticModel semanticModel)
+        {
+            var invocations = root.DescendantNodes().OfType<InvocationExpressionSyntax>();
+            foreach (var invocation in invocations)
+            {
+                if (semanticModel.GetOperation(invocation) is not IInvocationOperation operation)
+                    continue;
+
+                if (!loggingTypes.LoggerExtensionModeler.IsBeginScopeMethod(operation.TargetMethod))
+                    continue;
+
+                yield return ExtractBeginScopeUsage(operation, loggingTypes, invocation);
+            }
+        }
+
+        private static LoggerUsageInfo ExtractBeginScopeUsage(IInvocationOperation operation, LoggingTypes loggingTypes, InvocationExpressionSyntax invocation)
+        {
+            var usage = new LoggerUsageInfo
+            {
+                MethodName = operation.TargetMethod.Name,
+                MethodType = LoggerUsageMethodType.BeginScope,
+                Location = new MethodCallLocation
+                {
+                    StartLineNumber = invocation.GetLocation().GetLineSpan().StartLinePosition.Line,
+                    EndLineNumber = invocation.GetLocation().GetLineSpan().EndLinePosition.Line,
+                    FilePath = invocation.GetLocation().SourceTree!.FilePath
+                },
+            };
+
+            // Extract scope state information
+            ExtractScopeState(operation, usage);
+
+            return usage;
+        }
+
+        private static void ExtractScopeState(IInvocationOperation operation, LoggerUsageInfo usage)
+        {
+            // For extension methods, skip the first argument (this parameter)
+            // For core methods, use the first argument
+            int argumentIndex = operation.TargetMethod.IsExtensionMethod ? 1 : 0;
+            
+            if (operation.Arguments.Length <= argumentIndex)
+                return;
+
+            var stateArgument = operation.Arguments[argumentIndex];
+
+            // For now, just capture the argument as a string representation
+            // We'll enhance this to detect different scope types later
+            if (stateArgument.Value is ILiteralOperation literal && literal.ConstantValue.HasValue)
+            {
+                usage.MessageTemplate = literal.ConstantValue.Value?.ToString();
+            }
+            else
+            {
+                // For complex expressions, store the syntax representation
+                var syntaxNode = stateArgument.Syntax;
+                usage.MessageTemplate = syntaxNode.ToString();
+            }
+        }
+    }
+}

--- a/src/LoggerUsage/LoggerUsageExtractor.cs
+++ b/src/LoggerUsage/LoggerUsageExtractor.cs
@@ -15,11 +15,13 @@ public class LoggerUsageExtractor
 
     public LoggerUsageExtractor(ILoggerFactory loggerFactory)
     {
-        _logger = loggerFactory.CreateLogger<LoggerUsageExtractor>();        _analyzers =
+        _logger = loggerFactory.CreateLogger<LoggerUsageExtractor>();
+        _analyzers =
         [
             new LogMethodAnalyzer(loggerFactory),
             new LoggerMessageAttributeAnalyzer(loggerFactory),
-            new LoggerMessageDefineAnalyzer(loggerFactory)
+            new LoggerMessageDefineAnalyzer(loggerFactory),
+            new BeginScopeAnalyzer(loggerFactory),
         ];
     }
 

--- a/src/LoggerUsage/Models/LoggerUsageMethodType.cs
+++ b/src/LoggerUsage/Models/LoggerUsageMethodType.cs
@@ -8,5 +8,7 @@ public enum LoggerUsageMethodType
 
     LoggerMessageAttribute,
 
-    LoggerMessageDefine
+    LoggerMessageDefine,
+
+    BeginScope
 }


### PR DESCRIPTION
Enables detection and extraction of BeginScope method calls used in logging, improving coverage of logger usage analysis. Updates core logic to distinguish BeginScope from other logger methods and introduces targeted unit tests to validate correct recognition of both extension and core variants.