### PR TITLE
feature: Adds invocation tracking for LoggerMessage methods

### DIFF
--- a/src/LoggerUsage/Models/LoggerMessageInvocation.cs
+++ b/src/LoggerUsage/Models/LoggerMessageInvocation.cs
@@ -1,0 +1,22 @@
+namespace LoggerUsage.Models;
+
+/// <summary>
+/// Represents an invocation/call site of a LoggerMessage-attributed method.
+/// </summary>
+public class LoggerMessageInvocation
+{
+    /// <summary>
+    /// The fully qualified name of the containing type where the invocation occurs.
+    /// </summary>
+    public required string ContainingType { get; set; }
+
+    /// <summary>
+    /// Location where the method was invoked.
+    /// </summary>
+    public required MethodCallLocation InvocationLocation { get; set; }
+
+    /// <summary>
+    /// Arguments passed to the invocation (reusing existing MessageParameter model).
+    /// </summary>
+    public List<MessageParameter> Arguments { get; set; } = [];
+}

--- a/src/LoggerUsage/Models/LoggerMessageUsageInfo.cs
+++ b/src/LoggerUsage/Models/LoggerMessageUsageInfo.cs
@@ -1,0 +1,27 @@
+namespace LoggerUsage.Models;
+
+/// <summary>
+/// Extends LoggerUsageInfo with LoggerMessage-specific functionality including invocation tracking.
+/// </summary>
+public class LoggerMessageUsageInfo : LoggerUsageInfo
+{
+    /// <summary>
+    /// All invocations of this LoggerMessage method found in the analyzed code.
+    /// </summary>
+    public List<LoggerMessageInvocation> Invocations { get; set; } = [];
+
+    /// <summary>
+    /// The fully qualified name of the containing type where this LoggerMessage method is declared.
+    /// </summary>
+    public required string DeclaringTypeName { get; set; }
+
+    /// <summary>
+    /// Indicates whether this LoggerMessage method has any invocations.
+    /// </summary>
+    public bool HasInvocations => Invocations.Count > 0;
+
+    /// <summary>
+    /// The total number of invocations found for this LoggerMessage method.
+    /// </summary>
+    public int InvocationCount => Invocations.Count;
+}


### PR DESCRIPTION
Enhances the analyzer to track where LoggerMessage-attributed methods are called throughout the codebase. Introduces a two-phase analysis approach that first discovers method declarations, then finds all their invocations.

Creates new models to represent invocation data including call site locations, containing types, and argument information. Extends the base usage info with LoggerMessage-specific functionality that tracks invocation count and usage patterns.

Enables better understanding of LoggerMessage method usage across the application by providing visibility into both declaration and actual usage sites.