### PR TITLE
Migrate to NuGet.org trusted publishing

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -18,28 +18,28 @@ jobs:
     permissions:
       contents: read
       packages: write
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
-    
+
     - name: Restore dependencies
       run: dotnet restore
-    
+
     - name: Build solution
       run: dotnet build --configuration ${{ env.CONFIGURATION }} --no-restore
-    
+
     - name: Pack packages
       run: dotnet pack --configuration ${{ env.CONFIGURATION }} --no-build --output ./packages
-    
+
     - name: Add GitHub Packages source
       run: dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
-    
+
     - name: Publish packages to GitHub Packages
       run: |
         for package in ./packages/*.nupkg; do
@@ -50,28 +50,36 @@ jobs:
   publish-nuget-org:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    
+    permissions:
+      id-token: write  # enable GitHub OIDC token issuance for trusted publishing
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
-    
+
     - name: Restore dependencies
       run: dotnet restore
-    
+
     - name: Build solution
       run: dotnet build --configuration ${{ env.CONFIGURATION }} --no-restore
-    
+
     - name: Pack packages
       run: dotnet pack --configuration ${{ env.CONFIGURATION }} --no-build --output ./packages
-    
+
+    - name: NuGet login (OIDC → temp API key)
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: meirb  # Your nuget.org username
+
     - name: Publish packages to NuGet.org
       run: |
         for package in ./packages/*.nupkg; do
           echo "Publishing $package to NuGet.org..."
-          dotnet nuget push "$package" --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+          dotnet nuget push "$package" --source https://api.nuget.org/v3/index.json --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --skip-duplicate
         done


### PR DESCRIPTION
## Summary

This PR migrates the NuGet.org publishing process from API key-based authentication to trusted publishing using GitHub OIDC tokens.

## Changes Made

- ✅ **Added OIDC permissions**: Added id-token: write to the publish-nuget-org job
- ✅ **Integrated NuGet login action**: Added NuGet/login@v1 to obtain temporary API keys
- ✅ **Updated publishing commands**: Modified to use temporary API keys from the login step
- ✅ **Removed secret dependency**: No longer requires NUGET_API_KEY repository secret

## Benefits

- 🔒 **Enhanced Security**: Short-lived tokens (1 hour validity) instead of long-lived API keys
- 🚀 **Simplified Management**: No need to rotate secrets manually
- 📋 **Industry Standard**: Follows OpenSSF recommendations for secure, keyless publishing
- ⚡ **Automated Security**: Tokens are automatically issued and validated

## Prerequisites

- [x] Trusted publishing policy configured on nuget.org for this repository
- [x] Policy set for Repository Owner: 'Meir017', Repository: 'dotnet-logging-usage', Workflow File: 'publish-packages.yml'

## Testing Plan

After this PR is merged:
1. Create a test tag (e.g., 1.0.1-test) to verify the workflow
2. Ensure packages are published successfully to NuGet.org
3. Remove the old NUGET_API_KEY secret from repository settings

## Related Documentation

- [NuGet.org Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing)