### PR TITLE
Update README with proper NuGet.org badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 Create a summary of which log messages a project writes and the parameters to improve consistency
 
-[![LoggerUsage](https://img.shields.io/badge/nuget-LoggerUsage-blue?logo=nuget)](https://github.com/Meir017/dotnet-logging-usage/pkgs/nuget/LoggerUsage) - Core library for analyzing .NET logging usage patterns
+[![LoggerUsage](https://img.shields.io/nuget/v/LoggerUsage?style=flat-square&logo=nuget)](https://www.nuget.org/packages/LoggerUsage) [![LoggerUsage Downloads](https://img.shields.io/nuget/dt/LoggerUsage?style=flat-square&logo=nuget)](https://www.nuget.org/packages/LoggerUsage) - Core library for analyzing .NET logging usage patterns
 
-[![LoggerUsage.Cli](https://img.shields.io/badge/nuget-LoggerUsage.Cli-blue?logo=nuget)](https://github.com/Meir017/dotnet-logging-usage/pkgs/nuget/LoggerUsage.Cli) - Command-line tool for generating HTML/JSON reports
+[![LoggerUsage.Cli](https://img.shields.io/nuget/v/LoggerUsage.Cli?style=flat-square&logo=nuget)](https://www.nuget.org/packages/LoggerUsage.Cli) [![LoggerUsage.Cli Downloads](https://img.shields.io/nuget/dt/LoggerUsage.Cli?style=flat-square&logo=nuget)](https://www.nuget.org/packages/LoggerUsage.Cli) - Command-line tool for generating HTML/JSON reports
 
-[![LoggerUsage.Mcp](https://img.shields.io/badge/nuget-LoggerUsage.Mcp-blue?logo=nuget)](https://github.com/Meir017/dotnet-logging-usage/pkgs/nuget/LoggerUsage.Mcp) - Model Context Protocol server for AI integrations
+[![LoggerUsage.Mcp](https://img.shields.io/nuget/v/LoggerUsage.Mcp?style=flat-square&logo=nuget)](https://www.nuget.org/packages/LoggerUsage.Mcp) [![LoggerUsage.Mcp Downloads](https://img.shields.io/nuget/dt/LoggerUsage.Mcp?style=flat-square&logo=nuget)](https://www.nuget.org/packages/LoggerUsage.Mcp) - Model Context Protocol server for AI integrations
 
-[![LoggerUsage.MSBuild](https://img.shields.io/badge/nuget-LoggerUsage.MSBuild-blue?logo=nuget)](https://github.com/Meir017/dotnet-logging-usage/pkgs/nuget/LoggerUsage.MSBuild) - MSBuild integration for workspace analysis
+[![LoggerUsage.MSBuild](https://img.shields.io/nuget/v/LoggerUsage.MSBuild?style=flat-square&logo=nuget)](https://www.nuget.org/packages/LoggerUsage.MSBuild) [![LoggerUsage.MSBuild Downloads](https://img.shields.io/nuget/dt/LoggerUsage.MSBuild?style=flat-square&logo=nuget)](https://www.nuget.org/packages/LoggerUsage.MSBuild) - MSBuild integration for workspace analysis
 
 ## Background
 


### PR DESCRIPTION
## Summary

This PR updates the README to use proper NuGet.org badges instead of GitHub Packages badges, providing better visibility into package versions and download statistics.

## Changes Made

- ✅ **Version badges**: Show current package versions from NuGet.org
- ✅ **Download badges**: Display total download counts for each package
- ✅ **Modern styling**: Use flat-square style for clean appearance
- ✅ **Direct links**: All badges link to official NuGet.org package pages
- ✅ **Auto-updating**: Badges automatically refresh with new versions

## Badge Features

### Before
- Static GitHub Packages badges
- No version or download information
- Links to GitHub Packages (less discoverable)

### After
- Dynamic NuGet.org badges showing:
  - Current version number (e.g., v1.0.0)
  - Total download counts
  - Professional appearance with NuGet branding
  - Direct links to NuGet.org for easy package discovery

## Packages Updated

- **LoggerUsage** - Core library
- **LoggerUsage.Cli** - Command-line tool
- **LoggerUsage.Mcp** - Model Context Protocol server  
- **LoggerUsage.MSBuild** - MSBuild integration

## Benefits

- 📊 **Better visibility**: Users can immediately see current versions and popularity
- 🔗 **Improved discovery**: Direct links to official NuGet packages
- 📈 **Professional appearance**: Standard NuGet badge format
- ⚡ **Auto-updates**: No manual maintenance required for version changes