### PR TITLE
Suppress NU5104 warning for preview MCP package dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,9 @@
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
         <AnalysisLevel>latest</AnalysisLevel>
         
+        <!-- Package Warnings Suppression -->
+        <NoWarn>$(NoWarn);NU5104</NoWarn> <!-- Suppress warning for preview package dependencies -->
+        
         <!-- Version Management -->
         <Version>1.0.0-preview.2</Version>
         <AssemblyVersion>1.0.0.0</AssemblyVersion>


### PR DESCRIPTION
## Summary

This PR suppresses the NU5104 NuGet warning that occurs when packages have dependencies on prerelease/preview packages.

## Changes

- Added `<NoWarn>$(NoWarn);NU5104</NoWarn>` to `Directory.Build.props` to suppress the NU5104 warning
- Added descriptive comment explaining the purpose of the suppression

## Background

The NU5104 warning was being triggered by our dependency on `ModelContextProtocol.AspNetCore` version `0.2.0-preview.1` in the LoggerUsage.Mcp project. This is expected since we're using a preview package for the Model Context Protocol integration.

## Impact

- Resolves build warnings related to preview package dependencies
- No functional changes to the codebase
- Allows clean builds when using the preview MCP package

## Testing

- [x] Verified that the warning suppression works as expected
- [x] No impact on existing functionality
- [x] All tests should continue to pass