### PR TITLE
Remove coverlet.collector package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,5 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.4" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/test/LoggerUsage.Cli.Tests/LoggerUsage.Cli.Tests.csproj
+++ b/test/LoggerUsage.Cli.Tests/LoggerUsage.Cli.Tests.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
-    <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="xunit.v3" />

--- a/test/LoggerUsage.Mcp.Tests/LoggerUsage.Mcp.Tests.csproj
+++ b/test/LoggerUsage.Mcp.Tests/LoggerUsage.Mcp.Tests.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />

--- a/test/LoggerUsage.Tests/LoggerUsage.Tests.csproj
+++ b/test/LoggerUsage.Tests/LoggerUsage.Tests.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
-    <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging" />


### PR DESCRIPTION
## Summary
Removes the obsolete `coverlet.collector` package from the project.

## Changes
- ✅ Removed `coverlet.collector` from `Directory.Packages.props`
- ✅ Removed `coverlet.collector` references from all test projects:
  - `LoggerUsage.Tests`
  - `LoggerUsage.Cli.Tests`
  - `LoggerUsage.Mcp.Tests`

## Rationale
According to [official Microsoft documentation](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-extensions-code-coverage#coverlet):

> **Important**: The `coverlet.collector` NuGet package is designed specifically for VSTest and **cannot be used** with `Microsoft.Testing.Platform`.

Since this project uses `Microsoft.Testing.Platform` with `Microsoft.Testing.Extensions.CodeCoverage` (v18.0.4), the `coverlet.collector` package is:
- Incompatible with our testing infrastructure
- Redundant (we already have the official Microsoft code coverage solution)
- No longer maintained for our use case

## Testing
- All test projects continue to use `Microsoft.Testing.Extensions.CodeCoverage` for code coverage
- No functional changes to test execution or coverage reporting